### PR TITLE
Performance: Tell ggplot the format we expect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,12 @@ Description: ggplot2 extensions that work efficiently with matrices.
 URL: https://github.com/zeehio/ggmatrix
 BugReports: https://github.com/zeehio/ggmatrix/issues
 License: MIT + file LICENSE
-Depends: ggplot2
-Imports: rlang, grid, farver
+Depends:
+  ggplot2 (>= 3.3.6.9001)
+Imports:
+  farver (>= 2.1.1.9001),
+  grid,
+  rlang
 Encoding: UTF-8
 Language: en
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,5 +16,5 @@ Language: en
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 Remotes:
-  zeehio/ggplot2@all-perf-improvements,
+  zeehio/ggplot2@for-ggmatrix,
   thomasp85/farver#40

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,4 +17,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 Remotes:
   "zeehio/ggplot2@all-perf-improvements",
-  "zeehio/farver#40"
+  "thomasp85/farver#40"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,3 +15,6 @@ Encoding: UTF-8
 Language: en
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
+Remotes:
+  "zeehio/ggplot2@all-perf-improvements",
+  "zeehio/farver#40"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,5 +16,5 @@ Language: en
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 Remotes:
-  "zeehio/ggplot2@all-perf-improvements",
-  "thomasp85/farver#40"
+  zeehio/ggplot2@all-perf-improvements,
+  thomasp85/farver#40

--- a/R/geom_matrix_raster.R
+++ b/R/geom_matrix_raster.R
@@ -105,26 +105,26 @@ GeomMatrixRaster <- ggproto(
   non_missing_aes = c("fill"),
   required_aes = c("fill"),
   default_aes = aes(fill = "grey35"),
-  format_aes = function(params) {
+  scale_params = function(params) {
     nbins <- params$fill_nlevels
     if (nbins == Inf) {
       if (params$matrix_dtype == "double") {
         # real numbers are not so often duplicated
-        pal_strategy <- "raw"
+        mapping_method <- "raw"
       } else {
-        pal_strategy <- "unique"
+        mapping_method <- "unique"
       }
       list(
         "fill" = list(
           "color_fmt" = "native",
-          "map_palette_strategy" = pal_strategy
+          "mapping_method" = mapping_method
         )
       )
     } else {
       list(
         "fill" = list(
           "color_fmt" = "native",
-          "map_palette_strategy" = "binned",
+          "mapping_method" = "binned",
           "number_of_bins" = as.integer(params$fill_nlevels)
         )
       )
@@ -153,7 +153,12 @@ GeomMatrixRaster <- ggproto(
     x_rng <- range(corners$x, na.rm = TRUE)
     y_rng <- range(corners$y, na.rm = TRUE)
 
-    mat <- matrix(data$fill, nrow = mat_nr, ncol = mat_nc, byrow = byrow)
+    if (is.character(data$fill)) {
+      fill <- farver::encode_native(data$fill)
+    } else {
+      fill <- data$fill
+    }
+    mat <- matrix(fill, nrow = mat_nr, ncol = mat_nc, byrow = byrow)
 
     if (flip_cols) {
       rev_cols <- seq.int(mat_nc, 1L, by = -1L)


### PR DESCRIPTION
This commit improves performance by letting our geom tell ggplot that we want a native colour format and hinting the mapping strategy.

This requires further ggplot2 changes to be merged